### PR TITLE
Fix lint warning by moving PostGIS extension

### DIFF
--- a/supabase/migrations/20250613085801-2a20ff50-1c1f-46ef-97d9-7a1e7c3c1c5c.sql
+++ b/supabase/migrations/20250613085801-2a20ff50-1c1f-46ef-97d9-7a1e7c3c1c5c.sql
@@ -1,7 +1,8 @@
 
 -- Enable necessary extensions
+CREATE SCHEMA IF NOT EXISTS extensions;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-CREATE EXTENSION IF NOT EXISTS "postgis";
+CREATE EXTENSION IF NOT EXISTS "postgis" WITH SCHEMA extensions;
 
 -- Create enums
 CREATE TYPE public.app_role AS ENUM ('admin', 'project_manager', 'site_supervisor', 'foreman', 'worker', 'client');


### PR DESCRIPTION
## Summary
- avoid RLS warning for spatial_ref_sys by installing PostGIS in an `extensions` schema

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684df3d8d39083338fc15c86a249f559