### PR TITLE
Enable creating tasks

### DIFF
--- a/src/components/AddTaskDialog.tsx
+++ b/src/components/AddTaskDialog.tsx
@@ -1,0 +1,210 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { useForm } from 'react-hook-form';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { Plus } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+
+interface AddTaskFormData {
+  name: string;
+  description: string;
+  planned_start_date: string;
+  planned_end_date: string;
+  planned_hours: string;
+  priority: string;
+}
+
+export const AddTaskDialog = () => {
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const form = useForm<AddTaskFormData>({
+    defaultValues: {
+      name: '',
+      description: '',
+      planned_start_date: '',
+      planned_end_date: '',
+      planned_hours: '',
+      priority: '1',
+    },
+  });
+
+  const onSubmit = async (data: AddTaskFormData) => {
+    if (!data.name.trim()) {
+      toast({
+        title: 'Error',
+        description: 'Task name is required.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const { error } = await supabase.from('tasks').insert({
+        name: data.name.trim(),
+        description: data.description.trim() || null,
+        planned_start_date: data.planned_start_date || null,
+        planned_end_date: data.planned_end_date || null,
+        planned_hours: data.planned_hours ? parseFloat(data.planned_hours) : null,
+        priority: data.priority ? parseInt(data.priority, 10) : 1,
+        status: 'not_started',
+        progress_percentage: 0,
+      });
+
+      if (error) throw error;
+
+      toast({
+        title: 'Task Created',
+        description: 'New task has been successfully created.',
+      });
+
+      await queryClient.invalidateQueries({ queryKey: ['tasks'] });
+
+      form.reset();
+      setOpen(false);
+    } catch (error) {
+      console.error('Error creating task:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to create task. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          New Task
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Create New Task</DialogTitle>
+          <DialogDescription>Enter the details for the new task.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              rules={{ required: 'Task name is required' }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Task Name *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Inspection" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Task description" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="planned_start_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Start Date</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="planned_end_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>End Date</FormLabel>
+                    <FormControl>
+                      <Input type="date" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="planned_hours"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Planned Hours</FormLabel>
+                    <FormControl>
+                      <Input type="number" step="0.1" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="priority"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Priority</FormLabel>
+                    <FormControl>
+                      <Input type="number" min="1" max="5" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="flex justify-end space-x-2">
+              <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Creating...' : 'Create Task'}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -2,6 +2,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { AddTaskDialog } from '@/components/AddTaskDialog';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Plus, Search, ClipboardList, Calendar, User } from 'lucide-react';
@@ -102,10 +103,7 @@ const Tasks = () => {
             <p className="text-muted-foreground">Manage work assignments and progress</p>
           </div>
         </div>
-        <Button>
-          <Plus className="mr-2 h-4 w-4" />
-          New Task
-        </Button>
+        <AddTaskDialog />
       </div>
 
       {/* Search and Filters */}
@@ -187,10 +185,7 @@ const Tasks = () => {
           <ClipboardList className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
           <h3 className="text-lg font-medium mb-2">No tasks found</h3>
           <p className="text-muted-foreground mb-4">Get started by creating your first task</p>
-          <Button>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Task
-          </Button>
+          <AddTaskDialog />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- allow creating tasks via a new AddTaskDialog component
- use the dialog from the Tasks page for new tasks and empty state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684df57d92188333bf673ff01c416ba5